### PR TITLE
feat: clean up pre-production azure deployment when pr is closed

### DIFF
--- a/.github/workflows/deploy-azure-develop-clean.yaml
+++ b/.github/workflows/deploy-azure-develop-clean.yaml
@@ -1,0 +1,23 @@
+name: deploy-azure-develop-clean
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, develop]
+
+jobs:
+  clean-up:
+    name: Delete Azure Static WebApp pre-production environment
+    runs-on: ubuntu-latest
+    environment: testing
+    needs: [test, build-deploy]
+    env:
+      STATIC_WEB_APP_DEPLOYMENT_NAME: "#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}"
+
+    steps:
+      - name: Delete Azure Static WebApp pre-production environment
+        uses: azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DEVELOP }}
+          action: "close"
+          deployment_environment: ${{ env.STATIC_WEB_APP_DEPLOYMENT_NAME }}

--- a/.github/workflows/deploy-azure-develop.yaml
+++ b/.github/workflows/deploy-azure-develop.yaml
@@ -86,19 +86,3 @@ jobs:
           command: npx percy exec -- cypress run --config video=false,screenshotOnRunFailure=false,baseUrl=${{ env.STATIC_WEB_APP_URL}}
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-
-  clean-up:
-    name: Delete Azure Static WebApp pre-production environment
-    runs-on: ubuntu-latest
-    environment: testing
-    needs: [test, build-deploy]
-    env:
-      STATIC_WEB_APP_DEPLOYMENT_NAME: "#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}"
-
-    steps:
-      - name: Delete Azure Static WebApp pre-production environment
-        uses: azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DEVELOP }}
-          action: "close"
-          deployment_environment: ${{ env.STATIC_WEB_APP_DEPLOYMENT_NAME }}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
<!-- Delete not needed sections -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- the deployment to pre-production environment in Azure Static WebApps is automatically deleted when all e2e and visual regression tests pass, but this does not allow for manual inspection

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- only delete pre-production deployment when pull request is closed

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce -->

- [ ] Yes (TEST_FILE)
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
